### PR TITLE
fix(types): export output component types

### DIFF
--- a/.changeset/purple-fans-refuse.md
+++ b/.changeset/purple-fans-refuse.md
@@ -1,0 +1,5 @@
+---
+"@aonic-ui/pipelines": minor
+---
+
+export the output component types

--- a/packages/pipelines/src/components/index.ts
+++ b/packages/pipelines/src/components/index.ts
@@ -1,1 +1,2 @@
 export { Output, EnterpriseContract, AdvancedClusterSecurity, ResultsList } from './Output';
+export * from './Output/types';


### PR DESCRIPTION


Expose the output tab components such as EnterpriseContract, ACS component types to consumers.