### PR TITLE
fix(pipelines): replace static image url with actual image link

### DIFF
--- a/.changeset/red-months-travel.md
+++ b/.changeset/red-months-travel.md
@@ -1,0 +1,5 @@
+---
+'@aonic-ui/pipelines': patch
+---
+
+replace static image repo string with actual image link

--- a/packages/pipelines/src/components/Output/Tabs/AdvancedClusterSecurity/ImageCheck/ImageCheckTitle.tsx
+++ b/packages/pipelines/src/components/Output/Tabs/AdvancedClusterSecurity/ImageCheck/ImageCheckTitle.tsx
@@ -1,6 +1,9 @@
-import { Text, TextContent, TextVariants } from '@patternfly/react-core';
+import { Text, TextContent, TextVariants, Button } from '@patternfly/react-core';
+import { useACSContext } from '../AdvancedClusterSecurityContext';
 
 const ImageCheckTitle = () => {
+  const { acsImageCheckResults } = useACSContext();
+
   return (
     <TextContent
       style={{
@@ -8,7 +11,21 @@ const ImageCheckTitle = () => {
       }}
     >
       <Text component={TextVariants.p}>
-        This task returns ACS vulnerability image check results for image: quay.io/repo
+        This task returns ACS vulnerability image check results for image:{' '}
+        <Button
+          variant="link"
+          isInline
+          component={(props) => (
+            <a
+              {...props}
+              href={`https://${acsImageCheckResults?.results?.[0]?.metadata?.additionalInfo?.name}`}
+              target="_blank"
+              rel="noreferrer"
+            />
+          )}
+        >
+          {acsImageCheckResults?.results?.[0]?.metadata?.additionalInfo?.name}
+        </Button>
       </Text>
     </TextContent>
   );

--- a/packages/pipelines/src/components/Output/Tabs/AdvancedClusterSecurity/ImageScan/ImageScanTitle.tsx
+++ b/packages/pipelines/src/components/Output/Tabs/AdvancedClusterSecurity/ImageScan/ImageScanTitle.tsx
@@ -1,6 +1,9 @@
-import { Text, TextContent, TextVariants } from '@patternfly/react-core';
+import { Button, Text, TextContent, TextVariants } from '@patternfly/react-core';
+import { useACSContext } from '../AdvancedClusterSecurityContext';
 
 const ImageScanTitle = () => {
+  const { acsImageCheckResults } = useACSContext();
+
   return (
     <TextContent
       style={{
@@ -8,7 +11,21 @@ const ImageScanTitle = () => {
       }}
     >
       <Text component={TextVariants.p}>
-        This task returns ACS vulnerability scan results for image: quay.io/repo
+        This task returns ACS vulnerability scan results for image:{' '}
+        <Button
+          variant="link"
+          isInline
+          component={(props) => (
+            <a
+              {...props}
+              href={`https://${acsImageCheckResults?.results?.[0]?.metadata?.additionalInfo?.name}`}
+              target="_blank"
+              rel="noreferrer"
+            />
+          )}
+        >
+          {acsImageCheckResults?.results?.[0]?.metadata?.additionalInfo?.name}
+        </Button>
       </Text>
     </TextContent>
   );


### PR DESCRIPTION
Fixes:
https://github.com/redhat-developer/aonic-ui/issues/15
https://issues.redhat.com/browse/DEVUI-15

Remove the static quay image string and replace it with the real quay image coming from acs data

Before:

![static-string](https://github.com/redhat-developer/aonic-ui/assets/9964343/bf1cd6e2-06a2-4e62-bbf4-7566deefc86b)

After:
![image-url](https://github.com/redhat-developer/aonic-ui/assets/9964343/61dc7ce4-3301-4e55-8660-cba089957171)
