### PR TITLE
fix(pipelines): Handle invalid response on acs image check table gracefully

### DIFF
--- a/.changeset/slow-balloons-help.md
+++ b/.changeset/slow-balloons-help.md
@@ -1,0 +1,5 @@
+---
+"@aonic-ui/pipelines": patch
+---
+
+Handle the invalid input for acs table gracefully

--- a/packages/pipelines/src/components/Output/Tabs/AdvancedClusterSecurity/DeploymentCheck/DeploymentCheckSummary.tsx
+++ b/packages/pipelines/src/components/Output/Tabs/AdvancedClusterSecurity/DeploymentCheck/DeploymentCheckSummary.tsx
@@ -19,7 +19,7 @@ const DeploymentCheckSummary: React.FC = () => {
   );
 
   const breakingChangesSummary = React.useMemo(
-    () => getBreakingChangeCount(acsDeploymentCheckResults?.results[0]?.violatedPolicies),
+    () => getBreakingChangeCount(acsDeploymentCheckResults?.results?.[0]?.violatedPolicies),
     [acsDeploymentCheckResults],
   );
 

--- a/packages/pipelines/src/components/Output/Tabs/AdvancedClusterSecurity/ImageCheck/ImageCheckSummary.tsx
+++ b/packages/pipelines/src/components/Output/Tabs/AdvancedClusterSecurity/ImageCheck/ImageCheckSummary.tsx
@@ -18,7 +18,7 @@ const ImageCheckSummary: React.FC = () => {
     [acsImageCheckResults],
   );
   const breakingChangesSummary = React.useMemo(
-    () => getBreakingChangeCount(acsImageCheckResults?.results[0]?.violatedPolicies),
+    () => getBreakingChangeCount(acsImageCheckResults?.results?.[0]?.violatedPolicies),
     [acsImageCheckResults],
   );
 

--- a/packages/pipelines/src/components/Output/Tabs/AdvancedClusterSecurity/ImageCheck/__tests__/ImageCheckTable.test.tsx
+++ b/packages/pipelines/src/components/Output/Tabs/AdvancedClusterSecurity/ImageCheck/__tests__/ImageCheckTable.test.tsx
@@ -38,4 +38,20 @@ describe('ImageCheckTable', () => {
       screen.getByTestId('image-check-table');
     });
   });
+
+
+  test('should render the ImageCheckTable even if the results are not available', async () => {
+    render(
+      <ACSContextProvider
+        {...extraProps}
+        acsImageCheckResults={{ summary: acsImageCheckResults.summary } as ACSCheckResults}
+      >
+        <ImageCheckTable />
+      </ACSContextProvider>,
+    );
+
+   await waitFor(() => {
+      screen.getByTestId('image-check-table');
+    });
+  });
 });

--- a/packages/pipelines/src/components/Output/utils/summary-utils.tsx
+++ b/packages/pipelines/src/components/Output/utils/summary-utils.tsx
@@ -127,14 +127,14 @@ export const getBreakingChangeStatus = (
       return (
         <>
           <ExclamationTriangleIcon title={status} color={redColor.value} />{' '}
-          <b>{cveSummary?.[status]}</b> violations breaks build
+          <b>{cveSummary?.[status] ?? 0}</b> violations breaks build
         </>
       );
     case ACS_BREAKING_CHANGES.NotBreaking:
       return (
         <>
           <ExclamationTriangleIcon title={status} color={yellowColor.value} />{' '}
-          <b>{cveSummary?.[status]}</b> violations not breaking builds
+          <b>{cveSummary?.[status] ?? 0}</b> violations not breaking builds
         </>
       );
 
@@ -215,8 +215,8 @@ export const SummaryTextAndCount: React.FC<{
 );
 
 export const getCheckSeveritySummary = (data: ACSCheckResults) => ({
-  [ACS_IMAGE_CHECK_SEVERITY.Critical]: data.results?.[0]?.summary?.CRITICAL,
-  [ACS_IMAGE_CHECK_SEVERITY.High]: data.results?.[0]?.summary?.HIGH,
-  [ACS_IMAGE_CHECK_SEVERITY.Medium]: data.results?.[0]?.summary?.MEDIUM,
-  [ACS_IMAGE_CHECK_SEVERITY.Low]: data.results?.[0]?.summary?.LOW,
+  [ACS_IMAGE_CHECK_SEVERITY.Critical]: data.results?.[0]?.summary?.CRITICAL ?? 0,
+  [ACS_IMAGE_CHECK_SEVERITY.High]: data.results?.[0]?.summary?.HIGH ?? 0,
+  [ACS_IMAGE_CHECK_SEVERITY.Medium]: data.results?.[0]?.summary?.MEDIUM ?? 0,
+  [ACS_IMAGE_CHECK_SEVERITY.Low]: data.results?.[0]?.summary?.LOW ?? 0,
 });


### PR DESCRIPTION
**Fixes:**

https://github.com/janus-idp/backstage-plugins/issues/1355

**Description:**
ACS Image check table throws error when an invalid response is passed to the ACS ImageCheck table component.

**Screenshot:**

**Before**:

<img width="1134" alt="image" src="https://github.com/redhat-developer/aonic-ui/assets/9964343/146a0fd2-148c-4016-bd6c-f618046a8196">


**After**:
<img width="1170" alt="Screenshot 2024-03-20 at 8 40 38 PM" src="https://github.com/redhat-developer/aonic-ui/assets/9964343/8ce6b59b-8cea-40d8-9afa-b3838fd6888a">




**How to reproduce:**

1. Pass an invalid object in the AdvancedClusterSecurity.stories.tsx

```
export const ACSCard: Story = {
  args: {
    acsImageCheckResults: {summary: {}},
    acsImageScanResult,
    acsDeploymentCheckResults,
  },
  parameters: {},
};
```
2. Run the storybook and select AdvancedClusterSecurity docs.
