### PR TITLE
fix(pipelines): Handle invalid response on acs image scan tab gracefully

### DIFF
--- a/.changeset/gentle-bugs-yawn.md
+++ b/.changeset/gentle-bugs-yawn.md
@@ -1,0 +1,5 @@
+---
+"@aonic-ui/pipelines": patch
+---
+
+Handle the invalid data for acs image scan tab

--- a/packages/pipelines/src/components/Output/Tabs/AdvancedClusterSecurity/ImageScan/ImageScanSummary.tsx
+++ b/packages/pipelines/src/components/Output/Tabs/AdvancedClusterSecurity/ImageScan/ImageScanSummary.tsx
@@ -14,10 +14,10 @@ const ImageScanSummary: React.FC = () => {
   const { acsImageScanResult } = useACSContext();
 
   const getResultsSummary = (data: ACSImageScanResult) => ({
-    Critical: data.result.summary.CRITICAL,
-    Important: data.result.summary.IMPORTANT,
-    Moderate: data.result.summary.MODERATE,
-    Low: data.result.summary.LOW,
+    Critical: data.result?.summary?.CRITICAL ?? 0,
+    Important: data.result?.summary?.IMPORTANT ?? 0,
+    Moderate: data.result?.summary?.MODERATE ?? 0,
+    Low: data.result?.summary?.LOW ?? 0,
   });
 
   const resultSummary = React.useMemo(
@@ -96,7 +96,7 @@ const ImageScanSummary: React.FC = () => {
                   <SummaryTextAndCount
                     text={getCVEScanResults(
                       ACS_SCAN_RESULTS.Vulnerabilites,
-                      acsImageScanResult.result.summary,
+                      acsImageScanResult.result?.summary,
                     )}
                   />
                 </FlexItem>
@@ -105,7 +105,7 @@ const ImageScanSummary: React.FC = () => {
                     <SummaryTextAndCount
                       text={getCVEScanResults(
                         ACS_SCAN_RESULTS.Components,
-                        acsImageScanResult.result.summary,
+                        acsImageScanResult.result?.summary,
                       )}
                     />
                   </FlexItem>

--- a/packages/pipelines/src/components/Output/utils/__tests__/acs-filter-utils.test.ts
+++ b/packages/pipelines/src/components/Output/utils/__tests__/acs-filter-utils.test.ts
@@ -119,6 +119,25 @@ describe('ACS filter utils', () => {
   });
 
   describe('filterVulnerabilities', () => {
+    test('should return empty array for invalid data', () => {
+      const invalidACSImageScanData = {
+        result: {
+          summary: acsImageScanResult.result.summary,
+        },
+      } as ACSImageScanResult;
+
+      expect(
+        filterVulnerabilities(invalidACSImageScanData, {
+          statusFilters: [ACS_STATUS.Fixable],
+        }),
+      ).toHaveLength(0);
+
+      expect(
+        filterVulnerabilities({} as ACSImageScanResult, {
+          statusFilters: [ACS_STATUS.Fixable],
+        }),
+      ).toHaveLength(0);
+    });
     test('should filter vulnerabilities by status', () => {
       expect(
         filterVulnerabilities(acsImageScanResult, {

--- a/packages/pipelines/src/components/Output/utils/acs-filter-utils.ts
+++ b/packages/pipelines/src/components/Output/utils/acs-filter-utils.ts
@@ -38,8 +38,8 @@ export const filterVulnerabilities = (
     componentFilters = [],
     severityFilters = [],
   } = filters;
-  return !isEmpty(acsImageScanResult)
-    ? acsImageScanResult?.result?.vulnerabilities?.filter(
+  return !isEmpty(acsImageScanResult) && !!acsImageScanResult?.result?.vulnerabilities
+    ? acsImageScanResult.result.vulnerabilities?.filter(
         (vul: Vulnerability) =>
           filterByStatus(vul, statusFilters) &&
           filterData(vul, cveIdFilters, 'cveId') &&


### PR DESCRIPTION
Fixes:
https://issues.redhat.com/browse/RHTAPBUGS-1195


**Description:**

Handle invalid ACS data in ACS image-scan tab.

**Before:**

![image](https://github.com/redhat-developer/aonic-ui/assets/9964343/27915925-581b-4e70-8b39-913810179b27)

**After:**

![image](https://github.com/redhat-developer/aonic-ui/assets/9964343/8d168f31-21ae-46c4-8532-32286ef85c07)


**How to reproduce:**

1. Pass an invalid object in the AdvancedClusterSecurity.stories.tsx
```

export const ACSCard: Story = {
  args: {
    acsImageCheckResults,
    acsImageScanResult: : {result: {summary: {
          CRITICAL: 0,
          IMPORTANT: 0,
          LOW: 0,
          MODERATE: 0,
          'TOTAL-COMPONENTS': 0,
          'TOTAL-VULNERABILITIES': 0,
        }}},
    acsDeploymentCheckResults,
  },
  parameters: {},
};
```
2. Run the storybook and select AdvancedClusterSecurity docs.
