### PR TITLE
Export EC data transformer function

### DIFF
--- a/.changeset/yellow-crabs-chew.md
+++ b/.changeset/yellow-crabs-chew.md
@@ -1,0 +1,5 @@
+---
+"@aonic-ui/pipelines": patch
+---
+
+Export EC data transformer utility function

--- a/packages/pipelines/src/components/Output/index.ts
+++ b/packages/pipelines/src/components/Output/index.ts
@@ -1,2 +1,3 @@
 export { default as Output } from './Output';
+export { mapEnterpriseContractResultData as transformECResult } from './utils/data-transformer-utils';
 export { EnterpriseContract, AdvancedClusterSecurity, ResultsList } from './Tabs';

--- a/packages/pipelines/src/components/index.ts
+++ b/packages/pipelines/src/components/index.ts
@@ -1,3 +1,9 @@
-export { Output, EnterpriseContract, AdvancedClusterSecurity, ResultsList } from './Output';
+export {
+  Output,
+  EnterpriseContract,
+  AdvancedClusterSecurity,
+  ResultsList,
+  transformECResult,
+} from './Output';
 export * from './Output/types';
 export * from './Output/hooks/usePipelineRunOutput';


### PR DESCRIPTION


This PR exports a enterprise contract data transformer function called `transformECResult` which converts `EnterpriseContractResult` type object to `EnterpriseContractPolicy[]` object.